### PR TITLE
57 apply recoverytime

### DIFF
--- a/Assets/DataAssets/AttackData/MeleeAttack.asset
+++ b/Assets/DataAssets/AttackData/MeleeAttack.asset
@@ -15,6 +15,7 @@ MonoBehaviour:
   performer: {fileID: 11400000, guid: f32d350b53c96384990d519867acda0c, type: 2}
   attackMultiplier: 1
   attackDamage: 0
+  recoveryTime: 1
   breakable: 1
   attackInfo:
     causer: {fileID: 0}

--- a/Assets/DataAssets/AttackData/MeleeAttack_Player.asset
+++ b/Assets/DataAssets/AttackData/MeleeAttack_Player.asset
@@ -15,6 +15,7 @@ MonoBehaviour:
   performer: {fileID: 11400000, guid: f32d350b53c96384990d519867acda0c, type: 2}
   attackMultiplier: 1
   attackDamage: 0
+  recoveryTime: 1
   breakable: 1
   attackInfo:
     causer: {fileID: 0}

--- a/Assets/DataAssets/AttackData/RangeAttack.asset
+++ b/Assets/DataAssets/AttackData/RangeAttack.asset
@@ -15,6 +15,7 @@ MonoBehaviour:
   performer: {fileID: 11400000, guid: 8f2da7d80b078e34391856707b1e5c3f, type: 2}
   attackMultiplier: 1
   attackDamage: 0
+  recoveryTime: 0.5
   breakable: 0
   attackInfo:
     causer: {fileID: 0}

--- a/Assets/DataAssets/AttackData/UpperAttack.asset
+++ b/Assets/DataAssets/AttackData/UpperAttack.asset
@@ -15,6 +15,7 @@ MonoBehaviour:
   performer: {fileID: 11400000, guid: f32d350b53c96384990d519867acda0c, type: 2}
   attackMultiplier: 1
   attackDamage: 0
+  recoveryTime: 1
   breakable: 0
   attackInfo:
     causer: {fileID: 0}

--- a/Assets/Prefabs/Character/Player/Player.prefab
+++ b/Assets/Prefabs/Character/Player/Player.prefab
@@ -363,7 +363,7 @@ MonoBehaviour:
   stickingWallLayer:
     serializedVersion: 2
     m_Bits: 64
-  groundCheckDistance: 0.2
+  groundCheckDistance: 0.1
   wallCheckDistance: 0.05
   climbingLayer: 15
   isDefaultFacingRight: 1
@@ -485,8 +485,8 @@ MonoBehaviour:
       data:
         range: 1
         rangeMultiplier: 1
-        defaultRange: 1
-        thickness: 0.5
+        defaultRange: 0.5
+        thickness: 0.2
         padding: 0.3
         isVertical: 0
         isUpper: 1

--- a/Assets/Prefabs/Obstacle/InteractionObject/ChestObject.prefab
+++ b/Assets/Prefabs/Obstacle/InteractionObject/ChestObject.prefab
@@ -95,7 +95,7 @@ GameObject:
   - component: {fileID: 879753804237856254}
   - component: {fileID: 1278283041549885915}
   - component: {fileID: 3589035143340591632}
-  m_Layer: 10
+  m_Layer: 16
   m_Name: ChestObject
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Assets/Prefabs/Obstacle/InteractionObject/PushableObject.prefab
+++ b/Assets/Prefabs/Obstacle/InteractionObject/PushableObject.prefab
@@ -131,7 +131,7 @@ Rigidbody2D:
   m_Simulated: 1
   m_UseFullKinematicContacts: 0
   m_UseAutoMass: 0
-  m_Mass: 1
+  m_Mass: 10
   m_LinearDrag: 0
   m_AngularDrag: 0.05
   m_GravityScale: 1

--- a/Assets/Scripts/AttackData/AttackDataBase.cs
+++ b/Assets/Scripts/AttackData/AttackDataBase.cs
@@ -21,6 +21,7 @@ public class AttackDataBase : ScriptableObject
     public AttackPerformerBase performer;
     public float attackMultiplier;
     public float attackDamage;
+    public float recoveryTime;
     public bool breakable;
     public HitInfo attackInfo;
     public LayerMask overrideLayer;

--- a/Assets/Scripts/Characters/AI/Enemy/EnemyCharacterBase.cs
+++ b/Assets/Scripts/Characters/AI/Enemy/EnemyCharacterBase.cs
@@ -35,9 +35,18 @@ public class EnemyCharacterBase : AICharacterBase, IPoolable<EnemyCharacterBase>
         return result;
     }
 
-    public void PostAttack()
+    public void PostAttack(float recovery)
     {
-        _stateMachine.OnChase();
+        if (recovery > 0.05f)
+        {
+            if (this is IChaseable chasesable)
+            {
+                _stateMachine.OnWait(recovery, chasesable._chaseState);
+                return;
+            }
+        }
+        
+        ResetState();
     }
 
     protected override void Die()

--- a/Assets/Scripts/Characters/CharacterBase.cs
+++ b/Assets/Scripts/Characters/CharacterBase.cs
@@ -46,7 +46,7 @@ public interface IAttackable
 
     void ApplyDamage(IHitable target, DamageContext damageContext, HitInfo hitInfo);
     float CalculateDamage(DamageContext damageContext);
-    void PostAttack();
+    void PostAttack(float recovery);
 }
 
 public interface IStunable { public StunState _stunState { get; } }

--- a/Assets/Scripts/Characters/CharacterStateMachine.cs
+++ b/Assets/Scripts/Characters/CharacterStateMachine.cs
@@ -110,11 +110,11 @@ public class CharacterStateMachine : MonoBehaviour
         }
     }
 
-    public void OnAttackEnd()
+    public void OnAttackEnd(float recovery)
     {
         if (_attackable != null)
         {
-            _attackable.PostAttack();
+            _attackable.PostAttack(recovery);
         }
     }
 
@@ -176,7 +176,8 @@ public class CharacterStateMachine : MonoBehaviour
         {
             if (nextState != null) ChangeState(nextState);
             else OnIdle();
-                return;
+            
+            return;
         }
 
         _waitable._waitState.SetWaitTime(time);
@@ -261,10 +262,7 @@ public class CharacterStateMachine : MonoBehaviour
             _pushable._pushState.OnCancled();
         }
 
-        if (_currentState.IsMoveable)
-        {
-            _movement.SetMoveInput(Vector2.zero);
-        }
+        _movement.SetMoveInput(Vector2.zero);
 
         if (_aimming != null)
         {
@@ -279,7 +277,7 @@ public class CharacterStateMachine : MonoBehaviour
 
     public void OnEndJumpInput()
     {
-        if (_currentState.IsMoveable) _movement.EndJumppressed();
+        _movement.EndJumppressed();
     }
 
     public void OnInteractionInput()
@@ -431,6 +429,7 @@ public class CharacterStateMachine : MonoBehaviour
     void Update()
     {
         _currentState?.OnUpdate();
+
     }
 
     private void OnDisable()

--- a/Assets/Scripts/Characters/CharacterStateMachine.cs
+++ b/Assets/Scripts/Characters/CharacterStateMachine.cs
@@ -236,7 +236,10 @@ public class CharacterStateMachine : MonoBehaviour
 
     public void OnMoveInput(Vector2 input)
     {
-        _isMovePressed = true;
+        if (input.x < -0.1f || input.x > 0.1f)
+        {
+            _isMovePressed = true;
+        }
 
         if (_currentState.IsMoveable)
         {
@@ -323,29 +326,21 @@ public class CharacterStateMachine : MonoBehaviour
     private void ApplyPushInteraction(float inputx)
     {
         if (_pushable == null) return;
-        if (inputx < 0.1f && inputx > -0.1f)
-        {
-            _pushable._pushState.OnCancled();
-            return;
-        }
 
         float dir = _movement._isFacingRight ? 1 : -1;
 
-        if (dir * inputx < 0)
-        {
-            _pushable._pushState.OnCancled();
-            return;
-        }
+        if (dir * inputx < 0) return;
 
         IInteractable target = _interaction.GetPushTarget(inputx);
-        float pushRange = _interaction.GetPushSensorRange();
-
-        _pushable._pushState.SetPushTarget(target, pushRange);
 
         if (target != null)
         {
             if (!(_currentState is PushState))
             {
+                float pushRange = _interaction.GetPushSensorRange();
+
+                _pushable._pushState.SetPushTarget(target, pushRange);
+
                 ChangeState(_pushable._pushState);
             }
         }
@@ -424,7 +419,13 @@ public class CharacterStateMachine : MonoBehaviour
     {
         _currentState?.OnFiexedUpdate();
 
-        if (_isMovePressed && _currentState.IsInteractable) ApplyPushInteraction(_movement._moveInput.x);
+        if (_isMovePressed && _currentState.IsInteractable)
+        {
+            if (Mathf.Abs(_movement._rb.velocity.y) < 0.1f && _movement.CheckGround())
+            {
+                ApplyPushInteraction(_movement._moveInput.x);
+            }
+        }
     }
 
     void Update()

--- a/Assets/Scripts/Characters/CharacterStates/AttackState.cs
+++ b/Assets/Scripts/Characters/CharacterStates/AttackState.cs
@@ -14,6 +14,7 @@ public class AttackState : CharacterStateBase, IAimming
     private float _currentAimAngle;
     private float _currentAim;
     private float _currentCharge;
+    private float _recoveryTime;
     private bool _attackPressed;
 
     private IAimable _aimable;
@@ -42,6 +43,8 @@ public class AttackState : CharacterStateBase, IAimming
         SetAttackPressed(true);
 
         if (_aimable == null && _chargeable == null) OnAttackTrigger();
+
+        _recoveryTime = 0;
     }
 
     private void CastDataInterface()
@@ -90,11 +93,14 @@ public class AttackState : CharacterStateBase, IAimming
 
         if (_chargeable != null)
         {
+            if (_currentData.chargeAttackData == null) return;
+
             if (_chargeable.MinChargeTime <= _currentCharge)
             {
                 Debug.Log("Charge Success");
                 _attackContext.chargeRatio = _currentCharge / _chargeable.MaxChargeTime;
-                _currentData.chargeAttackData?.performer.Excute(_owner, _currentData.chargeAttackData, _attackContext);
+                _currentData.chargeAttackData.performer.Excute(_owner, _currentData.chargeAttackData, _attackContext);
+                _recoveryTime = _currentData.chargeAttackData.recoveryTime;
             }
             else
             {
@@ -103,7 +109,10 @@ public class AttackState : CharacterStateBase, IAimming
         }
         else
         {
-            _currentData.normalAttackData?.performer.Excute(_owner, _currentData.normalAttackData, _attackContext);
+            if (_currentData.normalAttackData == null) return;
+
+            _currentData.normalAttackData.performer.Excute(_owner, _currentData.normalAttackData, _attackContext);
+            _recoveryTime = _currentData.normalAttackData.recoveryTime;
         }
 
         PostAttack();
@@ -190,9 +199,7 @@ public class AttackState : CharacterStateBase, IAimming
 
     private void PostAttack()
     {
-
-        // TODO : 공격 후 후딜 처리
         if (weaponComp != null) weaponComp.SetCooldown(_currentData);
-        _stateMachine.OnAttackEnd();
+        _stateMachine.OnAttackEnd(_recoveryTime);
     }
 }

--- a/Assets/Scripts/Characters/CharacterStates/CharacterStateBase.cs
+++ b/Assets/Scripts/Characters/CharacterStates/CharacterStateBase.cs
@@ -39,7 +39,7 @@ public abstract class CharacterStateBase
     {
         _stateStartTime = Time.time;
 
-        _movement.EndJumppressed();
+        //_movement.EndJumppressed();
 
         _stateMachine.SetStateText(_stateName);
     }

--- a/Assets/Scripts/Characters/CharacterStates/PushState.cs
+++ b/Assets/Scripts/Characters/CharacterStates/PushState.cs
@@ -1,46 +1,40 @@
 using System.Collections;
 using System.Collections.Generic;
+using UnityEditor.ShaderKeywordFilter;
 using UnityEngine;
+using UnityEngine.Windows;
 using static UnityEngine.GraphicsBuffer;
 using static UnityEngine.RuleTile.TilingRuleOutput;
 
 public class PushState : CharacterStateBase
 {
     private IInteractable _pushTarget;
+    private float _pushRange;
+    private float _startDistanceY;
+    private Vector2 _originalSize;
 
     public PushState(CharacterBase character) : base(character) { }
 
     public void OnCancled()
     {
+        //Debug.Log("Push On Cancled");
         if (_pushTarget != null) _owner.ResetState();
     }
 
     public void SetPushTarget(IInteractable target, float range)
     {
-        if (target == null && _pushTarget == null) return;
+        _pushTarget = target;
+        _pushRange = range;
 
-        if (target == null)
-        {
-            if (_pushTarget != null)
-            {
-                float dist = Vector2.Distance(_owner.transform.position, _pushTarget.gameObject.transform.position);
-
-                if (dist > range + 0.5f)
-                {
-                    _owner.ResetState();
-                }
-            }
-
-            return;
-        }
-
-        if (_pushTarget != target) _pushTarget = target;
+        _startDistanceY = Mathf.Abs(_owner.transform.position.y - _pushTarget.gameObject.transform.position.y);
     }
 
     public override void OnStart()
     {
         _stateName = "¹Ð±â";
         base.OnStart();
+
+        //Debug.Log("On Push Start");
 
         //float dir = _owner._movement._isFacingRight ? 1 : -1;
         //var playerCol = _owner._mainCollider;
@@ -58,6 +52,10 @@ public class PushState : CharacterStateBase
 
         //_owner._rigidBody.velocity = Vector2.zero;
 
+        var col = _owner._mainCollider;
+        _originalSize = col.size;
+        col.size = new Vector2(_originalSize.x - 0.1f, _originalSize.y);
+
         _pushTarget?.OnInteraction(_owner.gameObject, InteractionType.Push);
     }
 
@@ -67,12 +65,71 @@ public class PushState : CharacterStateBase
 
     }
 
+    public override void OnFiexedUpdate()
+    {
+        base.OnFiexedUpdate();
+
+        CheckPushTarget();
+    }
+
     public override void OnExit()
     {
         base.OnExit();
 
-        //_owner._rigidBody.velocity = Vector2.zero;
+        //if (_pushTarget != null)
+        //{
+        //    Vector2 pos = _owner.transform.position;
+        //    float distX = _pushTarget.gameObject.transform.position.x - pos.x;
+        //    float exitDir = distX > 0 ? -1 : 1;
+
+        //    _owner._rigidBody.AddForce(new Vector2(exitDir * 1f, 0), ForceMode2D.Impulse);
+        //}
+
+        _owner._mainCollider.size = _originalSize;
+
         _pushTarget?.OnInteraction(_owner.gameObject, InteractionType.None);
         _pushTarget = null;
+    }
+
+    private void CheckPushTarget()
+    {
+        float inputx = _movement._moveInput.x;
+
+        if (inputx < 0.1f && inputx > -0.1f)
+        {
+            OnCancled();
+            return;
+        }
+
+        float dir = _movement._isFacingRight ? 1 : -1;
+
+        if (dir * inputx < 0)
+        {
+            OnCancled();
+            return;
+        }
+
+        IInteractable target = _stateMachine._interaction.GetPushTarget(inputx);
+
+        if (target == null && _pushTarget == null) return;
+
+        if (target == null)
+        {
+            //if (_pushTarget != target)
+            //{
+            //    OnCancled();
+            //}
+
+            float distX = Mathf.Abs(_owner.transform.position.x - _pushTarget.gameObject.transform.position.x);
+            float distY = Mathf.Abs(_owner.transform.position.y - _pushTarget.gameObject.transform.position.y);
+            //float dist = Vector2.Distance(_owner.transform.position, _pushTarget.gameObject.transform.position);
+
+            if (distX > _pushRange + 0.5f || distY > _startDistanceY + 0.2f)
+            {
+                OnCancled();
+            }
+        }
+
+        //if (_pushTarget != target) _pushTarget = target;
     }
 }

--- a/Assets/Scripts/Characters/CharacterStates/WaitState.cs
+++ b/Assets/Scripts/Characters/CharacterStates/WaitState.cs
@@ -7,7 +7,7 @@ public class WaitState : CharacterStateBase
     private float _currentTime;
     private CharacterStateBase _nextState;
 
-    public WaitState(CharacterBase character) : base(character) { }
+    public WaitState(CharacterBase character) : base(character) { _moveable = false; }
 
     public void SetWaitTime(float time) => _currentTime = time;
     public void SetNextState(CharacterStateBase nextState) => _nextState = nextState;
@@ -16,6 +16,9 @@ public class WaitState : CharacterStateBase
     {
         _stateName = "상태 전이 기다림";
         base.OnStart();
+
+        _stateMachine.OnEndMoveInput();
+        _stateMachine.OnEndJumpInput();
     }
 
     public override void OnUpdate()

--- a/Assets/Scripts/Characters/MovementComponent2D.cs
+++ b/Assets/Scripts/Characters/MovementComponent2D.cs
@@ -120,6 +120,7 @@ public class MovementComponent2D : MonoBehaviour
     public void SetMaxSpeedOnFlying(float speed) => _maxSpeed_flying = speed;
     public void IsIgnoreHoverHeight(bool ignore) => _ignoreHoverHeight = ignore;
     public void ClearJumpBuffer() => _lastJumpInputTime = -10;
+    public void UpdateCoyoteTime() => _lastGroundedTime = Time.time;
     public bool CanCoyoteJump() => Time.time - _lastGroundedTime <= _coyoteTimeThreshold;
     public bool HasJumpBuffer() => Time.time - _lastJumpInputTime <= _jumpBufferTime;
 
@@ -301,19 +302,61 @@ public class MovementComponent2D : MonoBehaviour
         _rb.AddForce(force, ForceMode2D.Impulse);
     }
 
+    //public bool CheckGround()
+    //{
+    //    if (_rb.velocity.y > 0.1f) return false;
+
+    //    float boxHeight = 0.1f;
+    //    Vector2 rayStart = new Vector2(_mainCollider.bounds.center.x, _mainCollider.bounds.min.y + (boxHeight * 0.5f));
+    //    Vector2 boxSize = new Vector2(_mainCollider.bounds.size.x * 0.8f, boxHeight);
+
+    //    RaycastHit2D[] hits = Physics2D.BoxCastAll(
+    //        rayStart,
+    //        boxSize,
+    //        0f,
+    //        Vector2.down,
+    //        groundCheckDistance,
+    //        groundLayer);
+
+    //    foreach (var hit in hits)
+    //    {
+    //        if (hit.collider.isTrigger) continue;
+
+    //        float feetY = _mainCollider.bounds.min.y;
+    //        float groundY = hit.point.y;
+
+    //        if (groundY <= feetY + 0.05f)
+    //        {
+    //            _groundHit = hit;
+    //            return true;
+    //        }
+    //    }
+
+    //    return false;
+    //}
+
     public bool CheckGround()
     {
+        float boxHeight = 0.1f;
+        Vector2 rayStart = new Vector2(_mainCollider.bounds.center.x, _mainCollider.bounds.min.y + (boxHeight * 0.5f));
+        Vector2 boxSize = new Vector2(_mainCollider.bounds.size.x * 0.8f, boxHeight);
+
         _groundHit = Physics2D.BoxCast(
-           _mainCollider.bounds.center,
-           new Vector2(_mainCollider.bounds.size.x * 0.9f, 0.1f),
-           0f,
-           Vector2.down,
-           _mainCollider.bounds.extents.y + groundCheckDistance,
-           groundLayer);
+            rayStart,
+            boxSize,
+            0f,
+            Vector2.down,
+            groundCheckDistance,
+            groundLayer);
+
+        if (_rb.velocity.y > 0.1f) return false;
 
         if (_groundHit.collider == null) return false;
 
-        _lastGroundedTime = Time.time;
+        float feetY = _mainCollider.bounds.min.y;
+        float groundY = _groundHit.point.y;
+
+        if (groundY > feetY + 0.05f) return false;
 
         return true;
     }

--- a/Assets/Scripts/Characters/MovementStates/FallingState.cs
+++ b/Assets/Scripts/Characters/MovementStates/FallingState.cs
@@ -8,6 +8,8 @@ public class FallingState : MovementStateBase, IMoveable, IJumpable
     private float _grabHoldTime = 0.0f;
     private float _currentblockTime;
     private float _currentHoldTime;
+    private float _groundCheckDelay = 0.15f;
+    private float _currentDelay;
 
     private float _startPosY;
 
@@ -20,12 +22,20 @@ public class FallingState : MovementStateBase, IMoveable, IJumpable
         _startPosY = _context.gameObject.transform.position.y;
         _currentblockTime = _grabBlockTime;
         _currentHoldTime = _grabHoldTime;
+        _currentDelay = _groundCheckDelay;
 
         _rb.gravityScale = _context._defaultGravityScale * _stats.fallMultiplier;
     }
-    public override void OnUpdate()
+
+    public override void OnFixedUpdate()
     {
-        base.OnUpdate();
+        base.OnFixedUpdate();
+
+        if (_currentDelay > 0)
+        {
+            _currentDelay -= Time.deltaTime;
+            return;
+        }
 
         if (_context.CheckGround())
         {
@@ -33,8 +43,7 @@ public class FallingState : MovementStateBase, IMoveable, IJumpable
 
             if (_context.HasJumpBuffer())
             {
-                _context.ClearJumpBuffer();
-                _context.ChangeMoveState(_context._jumpingState);
+                HandleCoyoteJump();
                 return;
             }
 
@@ -42,6 +51,13 @@ public class FallingState : MovementStateBase, IMoveable, IJumpable
         }
 
         HandleGrabInteraction();
+    }
+
+    public override void OnUpdate()
+    {
+        base.OnUpdate();
+
+        
     }
 
     public void Move(Vector2 input)
@@ -96,5 +112,19 @@ public class FallingState : MovementStateBase, IMoveable, IJumpable
             }
         }
         else _currentHoldTime = _grabHoldTime;
+    }
+
+    private void HandleCoyoteJump()
+    {
+        _context.ClearJumpBuffer();
+
+        if (_context.IsOnThinPlatform() && _context._moveInput.y < 0)
+        {
+            _context.ChangeMoveState(_context._droppingState);
+        }
+        else
+        {
+            _context.ChangeMoveState(_context._jumpingState);
+        }
     }
 }

--- a/Assets/Scripts/Characters/MovementStates/GroundedState.cs
+++ b/Assets/Scripts/Characters/MovementStates/GroundedState.cs
@@ -12,17 +12,26 @@ public class GroundedState : MovementStateBase, IMoveable, IJumpable
 
         _context.ResetJumpCount();
         _rb.gravityScale = _context._defaultGravityScale;
+        //_rb.velocity = new Vector2(_rb.velocity.x, -0.1f);
+    }
+
+    public override void OnFixedUpdate()
+    {
+        base.OnFixedUpdate();
+
+        if (!_context.CheckGround())
+        {
+            _context.UpdateCoyoteTime();
+            _context.ChangeMoveState(_context._fallingState);
+            return;
+        }
     }
 
     public override void OnUpdate()
     {
         base.OnUpdate();
 
-        if (!_context.CheckGround())
-        {
-            _context.ChangeMoveState(_context._fallingState);
-            return;
-        }
+        
     }
 
     public void Move(Vector2 input)

--- a/Assets/Scripts/Characters/PlayerCharacter/PlayerCharacter.cs
+++ b/Assets/Scripts/Characters/PlayerCharacter/PlayerCharacter.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using UnityEngine;
 
 [RequireComponent(typeof(WeaponComponent), typeof(InteractionComponent), typeof(PlayerController))]
-public class PlayerCharacter : CharacterBase, IAttackable, IStunable, IGroggyable, IHitable, ICarryable, IPushable, ILadderable
+public class PlayerCharacter : CharacterBase, IAttackable, IStunable, IGroggyable, IHitable, ICarryable, IPushable, ILadderable, IWaitable
 {
     [SerializeField] protected HitDatabase _hitDatabase;
     [SerializeField] private Transform _carryHoldSocket;
@@ -15,6 +15,7 @@ public class PlayerCharacter : CharacterBase, IAttackable, IStunable, IGroggyabl
     public CarryState _carryState { get; private set; }
     public PushState _pushState { get; private set; }
     public LadderState _ladderState { get; private set; }
+    public WaitState _waitState { get; private set; }
 
 
     public PlayerController _playerControlelr { get; private set; }
@@ -23,6 +24,7 @@ public class PlayerCharacter : CharacterBase, IAttackable, IStunable, IGroggyabl
 
     public HitDatabase HitData => _hitDatabase;
     public Transform CarryHoldSocket => _carryHoldSocket;
+
 
     protected override void OnAwake()
     {
@@ -62,6 +64,7 @@ public class PlayerCharacter : CharacterBase, IAttackable, IStunable, IGroggyabl
         _carryState = new CarryState(this);
         _pushState = new PushState(this);
         _ladderState = new LadderState(this);
+        _waitState = new WaitState(this);
     }
 
     public void ApplyDamage(IHitable target, DamageContext damageContext, HitInfo hitInfo)
@@ -82,8 +85,14 @@ public class PlayerCharacter : CharacterBase, IAttackable, IStunable, IGroggyabl
         return result;
     }
 
-    public void PostAttack()
+    public void PostAttack(float recovery)
     {
+        if (recovery > 0.05f)
+        {
+            _stateMachine.OnWait(recovery, _normalState);
+            return;
+        }
+
         ResetState();
     }
 

--- a/Assets/Scripts/Obstacles/Traps/TrapBase.cs
+++ b/Assets/Scripts/Obstacles/Traps/TrapBase.cs
@@ -52,7 +52,7 @@ public abstract class TrapBase : MonoBehaviour, IAttackable
         return result;
     }
 
-    public void PostAttack() { }
+    public void PostAttack(float recovery) { }
 
     protected abstract void OnActivate(GameObject Target);
 

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -21,7 +21,7 @@ TagManager:
   - Breakable
   - Sensor
   - ClimbingCharacter
-  - Ladder
+  - NonBlockInteraction
   - 
   - 
   - 


### PR DESCRIPTION
코요테 타임 구조 변경

PushState 버그 수정

성능 향상을 위해 밀기 가능한 오브젝트 체크를 x축 이동 입력이 있을 때만 수행하도록 변경
+ 지면에 닿아있으며, y축 velocity가 0이고 인터렉션 가능한 상태일 때

공격 후딜레이 (recovery time) 적용
- WeaponData가 아닌, AttackData에 해당 수치 반영
- 공격 별 (차징, 노멀) 수치가 다를 수 있다는 판단

